### PR TITLE
Fixed Copy Commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:18-alpine
 WORKDIR /app
 
-COPY package*.json .
+COPY package.json .
+COPY package-lock.json .
+
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
In a Dockerfile, when using COPY with more than one source file, the destination must be a directory and end with a `/.` Or, you can specify each file that needs to be copied.

This change will allow the docker image to be built. 