### PR TITLE
Fix time flickering when frame is first displayed

### DIFF
--- a/server/scripts/modules/weatherdisplay.mjs
+++ b/server/scripts/modules/weatherdisplay.mjs
@@ -151,6 +151,7 @@ class WeatherDisplay {
 	drawCanvas() {
 		// clean up the first-run flag in screen index
 		if (this.screenIndex < 0) this.screenIndex = 0;
+		if (this.okToDrawCurrentDateTime) this.drawCurrentDateTime();
 	}
 
 	finishDraw() {
@@ -159,14 +160,13 @@ class WeatherDisplay {
 			this.drawCurrentDateTime();
 			// auto clock refresh
 			if (!this.dateTimeInterval) {
-				setInterval(() => this.drawCurrentDateTime(), 100);
+				// only draw if canvas is active to conserve battery
+				setInterval(() => this.active && this.drawCurrentDateTime(), 100);
 			}
 		}
 	}
 
 	drawCurrentDateTime() {
-		// only draw if canvas is active to conserve battery
-		if (!this.active) return;
 		// Get the current date and time.
 		const now = DateTime.local().setZone(timeZone());
 


### PR DESCRIPTION
When a frame is first displayed sometimes there is a flickering effect with the current time. It either briefly shows an older time or an empty value before rendering the current time. This change fixes this by calling `drawCurrentTime` from within `drawCanvas` without having to wait for the first timer interval. The optimization to only render the time when the frame is active has been moved to the interval lambda. 