### PR TITLE
Update the script to build the css and minimize it to work with the files checked in

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"build:css": "sass ./server/styles/scss/style.scss ./server/styles/compiled.css",
+		"build:css": "sass --style=compressed ./server/styles/scss/main.scss ./server/styles/main.css",
 		"lint": "eslint ./server/scripts/**/*.mjs",
 		"lint:fix": "eslint --fix ./server/scripts/**/*.mjs"
 	},


### PR DESCRIPTION
I was running into issues starting fresh locally working with the CSS and noticed that the script for building the css didn't point to the write files or included the compressed style of the finished output.  This should fix that part. 