### PR TITLE
Add version tags to Docker build

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -10,19 +10,22 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - id: short-sha
-        uses: benjlevesque/short-sha@v1.2
+        uses: actions/checkout@v4
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
             ghcr.io/netbymatt/ws4kp
+          flavor: |
+            latest=false
           tags: |
             type=raw,priority=1000,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
-            ${{ steps.short-sha.outputs.sha }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Buildx


### PR DESCRIPTION
This PR will add the semver tags from Git to the Docker image builds. For code pushed to `main`, with a tag of `v1.2.3` the following tags would get added:
```
latest
1
1.2
1.2.3
main
sha-1234567
```
Code pushed to branches other than main will have tags for their branch, and for their Git SHA, and will not be tagged with `latest`.

This PR also changes away from using a separate action to determine the SHA. The only difference to end users is that the Docker tag with the SHA will now be prefixed with `sha-`.