### PR TITLE
Update README to include `ws4kp-international`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This project is based on the work of [Mike Battaglia](https://github.com/vbguyny
 
 ## Does WeatherStar 4000+ work outside of the USA?
 
-This project is tightly coupled to [NOAA's Weather API](https://www.weather.gov/documentation/services-web-api), which is exclsuive to the United States. Using NOAA's Weather API is a crucial requirement to providing an authentic WeatherStar 4000+ experience.
+This project is tightly coupled to [NOAA's Weather API](https://www.weather.gov/documentation/services-web-api), which is exclsuive to the United States. Using NOAA's Weather API is a crucial requirement to provide an authentic WeatherStar 4000+ experience.
 
-If you would like to display information for locations outside of the USA, please checkout a fork of this project created by @mwood77:
+If you would like to display weather information for international locations (outside of the USA), please checkout a fork of this project created by @mwood77:
 - https://github.com/mwood77/ws4kp-international
 
 ## Run Your WeatherStar

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ This project is based on the work of [Mike Battaglia](https://github.com/vbguyny
 	* [Icon](https://twcclassics.com/downloads.html) sets
 	* Countless photos and videos of WeatherStar 4000 forecasts used as references.
 
+## Does WeatherStar 4000+ work outside of the USA?
+
+This project is tightly coupled to [NOAA's Weather API](https://www.weather.gov/documentation/services-web-api), which is exclsuive to the United States. Using NOAA's Weather API is a crucial requirement to providing an authentic WeatherStar 4000+ experience.
+
+If you would like to display information for locations outside of the USA, please checkout a fork of this project created by @mwood77:
+- https://github.com/mwood77/ws4kp-international
+
 ## Run Your WeatherStar
 There are a lot of CORS considerations and issues with api.weather.gov that are easiest to deal with by running a local server to see this in action (or use the live link above). You'll need Node.js >12.0 to run the local server.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This project is based on the work of [Mike Battaglia](https://github.com/vbguyny
 
 This project is tightly coupled to [NOAA's Weather API](https://www.weather.gov/documentation/services-web-api), which is exclsuive to the United States. Using NOAA's Weather API is a crucial requirement to provide an authentic WeatherStar 4000+ experience.
 
-If you would like to display weather information for international locations (outside of the USA), please checkout a fork of this project created by @mwood77:
-- https://github.com/mwood77/ws4kp-international
+If you would like to display weather information for international locations (outside of the USA), please checkout a fork of this project created by [@mwood77](https://github.com/mwood77):
+- [`ws4kp-international`](https://github.com/mwood77/ws4kp-international)
 
 ## Run Your WeatherStar
 There are a lot of CORS considerations and issues with api.weather.gov that are easiest to deal with by running a local server to see this in action (or use the live link above). You'll need Node.js >12.0 to run the local server.


### PR DESCRIPTION
Adds a block in the readme which discuss `ws4kp`'s data source and why it's exclusive to the USA. Also adds a callout to [`ws4kp-international`](https://github.com/mwood77/ws4kp-international). Related to the discussion in #63 .