### PR TITLE
Fix bug where music playlist does not loop

### DIFF
--- a/server/scripts/modules/media.mjs
+++ b/server/scripts/modules/media.mjs
@@ -149,7 +149,7 @@ const playerEnded = () => {
 	// next track
 	currentTrack += 1;
 	// roll over and re-randomize the tracks
-	if (currentTrack >= playlist.availableFiles) {
+	if (currentTrack >= playlist.availableFiles.length) {
 		randomizePlaylist();
 		currentTrack = 0;
 	}


### PR DESCRIPTION
The music player was crashing when currentTrack was higher than the playlist size due to a missing `.length`.

To test, note that before the PR ws4kp will give throw an error in the console after the last song of the playlist finishes and music will stop playing.

After the PR, music will continue playing after the entire playlist has been played.