### PR TITLE
update local run instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run via Node locally:
 git clone https://github.com/netbymatt/ws4kp.git
 cd ws4kp
 npm i
-node index.js
+node index.mjs
 ```
 
 To run via Docker: 


### PR DESCRIPTION
Slight change to the readme. A very minor issue, but technically the file extension for the node run command is incorrect.