### PR TITLE
Gracefully shutdown on both SIGINT + SIGTERM

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -99,8 +99,11 @@ const server = app.listen(port, () => {
 });
 
 // graceful shutdown
-process.on('SIGINT', () => {
+const gracefulShutdown = () => {
 	server.close(() => {
 		console.log('Server closed');
 	});
-});
+};
+
+process.on('SIGINT', gracefulShutdown);
+process.on('SIGTERM', gracefulShutdown);


### PR DESCRIPTION
Most service managers (systemd, docker, etc) use SIGTERM as the shutdown signal by default rather than SIGINT (which is used for interactive CTRL-C).

The lack of `SIGTERM` is causing a ~30sec delay to restart this service in my Kubernetes cluster since it sends a `SIGTERM` and then waits the 30sec grace period before following up with a `SIGKILL`.