### PR TITLE
Expand radar feature disabling to cover all iOS browsers and the Messages crawler

### DIFF
--- a/server/scripts/modules/radar.mjs
+++ b/server/scripts/modules/radar.mjs
@@ -9,12 +9,24 @@ import * as utils from './radar-utils.mjs';
 // TEMPORARY fix to disable radar on ios safari
 const isIos = /iP(ad|od|hone)/i.test(window.navigator.userAgent);
 const isSafari = !!navigator.userAgent.match(/Version\/[\d.]+.*Safari/);
+// NOTE: iMessages/Messages preview is provided by an Apple scraper that uses a
+// user-agent similar to: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1)
+// AppleWebKit/601.2.4 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.4
+// facebookexternalhit/1.1 Facebot Twitterbot/1.0`. There is currently a bug in
+// Messages macos/ios where a constantly crashing website seems to cause an
+// entire Messages thread to permanently lockup until the individual website
+// preview is deleted! Messages ios will judder but allows the message to be
+// deleted eventually. Messages macos beachballs forever and prevents the
+// successful deletion. See
+// https://github.com/netbymatt/ws4kp/issues/74#issuecomment-2921154962 for more
+// context.
+const isBot = /twitterbot|Facebot/i.test(window.navigator.userAgent);
 const safariIos = isIos && isSafari;
 
 const RADAR_HOST = 'mesonet.agron.iastate.edu';
 class Radar extends WeatherDisplay {
 	constructor(navId, elemId) {
-		super(navId, elemId, 'Local Radar', !safariIos);
+		super(navId, elemId, 'Local Radar', !safariIos && !isBot);
 
 		this.okToDrawCurrentConditions = false;
 		this.okToDrawCurrentDateTime = false;
@@ -207,7 +219,7 @@ const radarWorker = () => {
 };
 
 // register display
-// TEMPORARY: except on safari on IOS
-if (!safariIos) {
+// TEMPORARY: except on safari on IOS and bots
+if (!safariIos && !isBot) {
 	registerDisplay(new Radar(11, 'radar'));
 }

--- a/server/scripts/modules/radar.mjs
+++ b/server/scripts/modules/radar.mjs
@@ -6,9 +6,10 @@ import WeatherDisplay from './weatherdisplay.mjs';
 import { registerDisplay, timeZone } from './navigation.mjs';
 import * as utils from './radar-utils.mjs';
 
-// TEMPORARY fix to disable radar on ios safari
+// TEMPORARY fix to disable radar on ios safari. The same engine (webkit) is
+// used for all ios browers (chrome, brave, firefox, etc) so it's safe to skip
+// any subsequent narrowing of the user-agent.
 const isIos = /iP(ad|od|hone)/i.test(window.navigator.userAgent);
-const isSafari = !!navigator.userAgent.match(/Version\/[\d.]+.*Safari/);
 // NOTE: iMessages/Messages preview is provided by an Apple scraper that uses a
 // user-agent similar to: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1)
 // AppleWebKit/601.2.4 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.4
@@ -21,12 +22,11 @@ const isSafari = !!navigator.userAgent.match(/Version\/[\d.]+.*Safari/);
 // https://github.com/netbymatt/ws4kp/issues/74#issuecomment-2921154962 for more
 // context.
 const isBot = /twitterbot|Facebot/i.test(window.navigator.userAgent);
-const safariIos = isIos && isSafari;
 
 const RADAR_HOST = 'mesonet.agron.iastate.edu';
 class Radar extends WeatherDisplay {
 	constructor(navId, elemId) {
-		super(navId, elemId, 'Local Radar', !safariIos && !isBot);
+		super(navId, elemId, 'Local Radar', !isIos && !isBot);
 
 		this.okToDrawCurrentConditions = false;
 		this.okToDrawCurrentDateTime = false;
@@ -219,7 +219,7 @@ const radarWorker = () => {
 };
 
 // register display
-// TEMPORARY: except on safari on IOS and bots
-if (!safariIos && !isBot) {
+// TEMPORARY: except on IOS and bots
+if (!isIos && !isBot) {
 	registerDisplay(new Radar(11, 'radar'));
 }


### PR DESCRIPTION
As I mentioned in https://github.com/netbymatt/ws4kp/issues/74#issuecomment-2926523514, the radar feature was still causing consistent crashing in Firefox iOS (and presumably Chrome and Brave iOS too) as well as causing the Messages app on iOS/MacOS to stall/beachball forever (obviously a bug in Messages, but it's faster to fix this one site than wait for a fix from Apple!).

This PR widens the user-agent check for all iOS browsers as well as checks for twitter/facebook crawlers, [which the Messages crawler masquerades](https://stackoverflow.com/questions/41499402/what-is-the-user-agent-string-for-ios-macos-imessage) as (I confirmed this through manually checking myself using latest iOS).

Sample User-Agents:

- Firefox iOS: `Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/138.3 Mobile/15E148 Safari/605.1.15`
- Messages crawler (for both Messages iOS and MacOS): `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/601.2.4 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.4 facebookexternalhit/1.1 Facebot Twitterbot/1.0`

