### PR TITLE
chore: update dockerfile to Node 24 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:24-alpine
 WORKDIR /app
 
 COPY package.json .


### PR DESCRIPTION
Node 18 has been EOL for a little while, bumping to Node 24. 