### PR TITLE
Remove ARMv7 from builds

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -3,7 +3,7 @@ name: build-docker
 on:
   push:
     branches:
-      - main
+      - '**'
     tags:
       - 'v*.*.*'
       - 'v*.*'
@@ -50,7 +50,7 @@ jobs:
           context: .
           pull: true
           push: ${{ github.ref == 'refs/heads/main' }}
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
It appears Node has stopped shipping an ARMv7 Docker image with more recent versions, which is breaking this project's Docker builds. Additionally, ARMv7 is being deprecated community-wide, with Home Assistant (for example) dropping support later this year.

This PR removes the ARMv7 build.