### PR TITLE
Docker: Add mime.types To nginx Configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,7 @@
 server {
     listen 8080;
     server_name localhost;
+    include mime.types;
 
     root /usr/share/nginx/html;
 


### PR DESCRIPTION
Explicit configuration of nginx MIME types is required for the proper operation the radar viewer.

Fixes: #115 