### PR TITLE
Increase local forecast timing to better match original Weather Star

### DIFF
--- a/server/scripts/modules/localforecast.mjs
+++ b/server/scripts/modules/localforecast.mjs
@@ -9,7 +9,7 @@ import filterExpiredPeriods from './utils/forecast-utils.mjs';
 import { debugFlag } from './utils/debug.mjs';
 
 class LocalForecast extends WeatherDisplay {
-	static BASE_FORECAST_DURATION_MS = 5000; // Base duration (in ms) for a standard 3-5 line forecast page
+	static BASE_FORECAST_DURATION_MS = 10000; // Base duration (in ms) for a standard 3-5 line forecast page
 
 	constructor(navId, elemId) {
 		super(navId, elemId, 'Local Forecast', true);


### PR DESCRIPTION
Increase the Local Forecast base display time from 5 seconds to 10 seconds. The current default is too short for longer lines, even with the existing multiplier, and 10 seconds more closely matches the original Weather Star timing seen in archived recordings.