### PR TITLE
Fix vertical scroll freezing after content is rebuilt

### DIFF
--- a/server/scripts/modules/hazards.mjs
+++ b/server/scripts/modules/hazards.mjs
@@ -18,6 +18,10 @@ const hazardModifiers = {
 	'Severe Thunderstorm Warning': 1,
 };
 
+// A cheap, stable signature of the content about to be rendered. Alert ids alone are not enough:
+// an alert can be reissued under the same id with updated text, which changes the rendered height.
+const contentSignature = (alerts) => alerts.map((alert) => `${alert.id}|${alert.properties.event}|${alert.properties.description ?? ''}`).join('\u0000');
+
 class Hazards extends WeatherDisplay {
 	constructor(navId, elemId, defaultActive) {
 		// special height and width for scrolling
@@ -47,6 +51,10 @@ class Hazards extends WeatherDisplay {
 			maxOffset: 0,
 			hazardLines: null,
 		};
+
+		// signature of the content currently rendered into the DOM, so a refresh that returns
+		// identical alerts can skip the rebuild entirely
+		this.lastContentSignature = null;
 	}
 
 	async getData(weatherParameters, refresh) {
@@ -128,10 +136,22 @@ class Hazards extends WeatherDisplay {
 	async drawLongCanvas() {
 		// get the list element and populate
 		const list = this.elem.querySelector('.hazard-lines');
-		list.innerHTML = '';
 
 		// filter viewed alerts
 		const unViewed = this.data.filter((data) => !this.viewedAlerts.has(data.id));
+
+		// If the content is identical to what is already rendered, leave the DOM and the scroll
+		// position alone. Hazards refresh every 60 seconds but a long multi-alert scroll can run for
+		// several minutes, so rebuilding on every refresh would restart it from the top and it would
+		// never reach the end. The populated-list check means an empty list is always rebuilt.
+		const signature = contentSignature(unViewed);
+		if (signature === this.lastContentSignature && list.children.length > 0) {
+			this.setStatus(STATUS.loaded);
+			return;
+		}
+		this.lastContentSignature = signature;
+
+		list.innerHTML = '';
 
 		const lines = unViewed.map((data) => {
 			const fillValues = {};
@@ -146,6 +166,18 @@ class Hazards extends WeatherDisplay {
 		});
 
 		list.append(...lines);
+
+		// The scroll cache is invalidated by comparing element identity, but .hazard-lines is
+		// persistent - only its children are replaced above - and displayHeight is a fixed value
+		// from css. Both conditions in baseCountChange() therefore stay false after the first
+		// measurement, so maxOffset keeps the height of whatever content was measured first and
+		// clamps the scroll partway through anything taller, leaving it frozen there. Invalidate
+		// explicitly so the next base count re-measures.
+		this.scrollCache.displayHeight = 0;
+		this.scrollCache.hazardLines = null;
+
+		// new content scrolls from the top
+		this.navBaseCount = 0;
 
 		// no alerts, skip this display by setting timing to zero
 		if (lines.length === 0) {

--- a/server/scripts/modules/hourly.mjs
+++ b/server/scripts/modules/hourly.mjs
@@ -12,6 +12,14 @@ import getSun from './almanac.mjs';
 import calculateScrollTiming from './utils/scroll-timing.mjs';
 import { debugFlag } from './utils/debug.mjs';
 
+// A cheap, stable signature of the content about to be rendered. The starting hour is included
+// because the row labels are derived from the current time, so an hour rollover changes the display
+// even when every forecast value is unchanged.
+const contentSignature = (startingHour, rows) => [
+	startingHour.startOf('hour').toISO(),
+	...rows.map((row) => `${row.temperature}|${row.apparentTemperature}|${row.windSpeed}|${row.windDirection}|${row.icon}`),
+].join('\u0000');
+
 class Hourly extends WeatherDisplay {
 	constructor(navId, elemId, defaultActive) {
 		// special height and width for scrolling
@@ -28,6 +36,10 @@ class Hourly extends WeatherDisplay {
 			maxOffset: 0,
 			hourlyLines: null,
 		};
+
+		// signature of the content currently rendered into the DOM, so a refresh that returns
+		// identical rows can skip the rebuild entirely
+		this.lastContentSignature = null;
 	}
 
 	async getData(weatherParameters, refresh) {
@@ -71,12 +83,19 @@ class Hourly extends WeatherDisplay {
 	async drawLongCanvas() {
 		// get the list element and populate
 		const list = this.elem.querySelector('.hourly-lines');
-		list.innerHTML = '';
 
 		const startingHour = DateTime.local().setZone(timeZone());
 
 		// shorten to 24 hours
 		const shortData = this.data.slice(0, 24);
+
+		// if the content is identical to what is already rendered, leave the DOM and the scroll
+		// position alone rather than rebuilding and restarting an in-progress scroll
+		const signature = contentSignature(startingHour, shortData);
+		if (signature === this.lastContentSignature && list.children.length > 0) return;
+		this.lastContentSignature = signature;
+
+		list.innerHTML = '';
 
 		const lines = shortData.map((data, index) => {
 			const fillValues = {};
@@ -115,6 +134,18 @@ class Hourly extends WeatherDisplay {
 		});
 
 		list.append(...lines);
+
+		// The scroll cache is invalidated by comparing element identity, but .hourly-lines is
+		// persistent - only its children are replaced above - and displayHeight is a fixed value
+		// from css. Both conditions in baseCountChange() therefore stay false after the first
+		// measurement, so maxOffset keeps the height of whatever content was measured first and
+		// clamps the scroll partway through anything taller, leaving it frozen there. Invalidate
+		// explicitly so the next base count re-measures.
+		this.scrollCache.displayHeight = 0;
+		this.scrollCache.hourlyLines = null;
+
+		// new content scrolls from the top
+		this.navBaseCount = 0;
 
 		// update timing based on actual content
 		this.setTiming(list);

--- a/server/scripts/modules/travelforecast.mjs
+++ b/server/scripts/modules/travelforecast.mjs
@@ -9,6 +9,13 @@ import settings from './settings.mjs';
 import calculateScrollTiming from './utils/scroll-timing.mjs';
 import { debugFlag } from './utils/debug.mjs';
 
+// A cheap, stable signature of the content about to be rendered. Only the fields that reach the DOM
+// are included. Rows for cities whose forecast failed are dropped from the rendered list, so the row
+// count - and therefore the rendered height - changes as individual cities come and go.
+const contentSignature = (cities) => cities.map((city) => (city.error
+	? `${city.name}|error`
+	: `${city.name}|${city.high}|${city.low}|${city.icon}`)).join('\u0000');
+
 class TravelForecast extends WeatherDisplay {
 	constructor(navId, elemId, defaultActive) {
 		// special height and width for scrolling
@@ -29,6 +36,10 @@ class TravelForecast extends WeatherDisplay {
 			maxOffset: 0,
 			travelLines: null,
 		};
+
+		// signature of the content currently rendered into the DOM, so a refresh that returns
+		// identical cities can skip the rebuild entirely
+		this.lastContentSignature = null;
 	}
 
 	async getData(weatherParameters, refresh) {
@@ -101,10 +112,17 @@ class TravelForecast extends WeatherDisplay {
 	async drawLongCanvas() {
 		// get the element and populate
 		const list = this.elem.querySelector('.travel-lines');
-		list.innerHTML = '';
 
 		// set up variables
 		const cities = this.data;
+
+		// if the content is identical to what is already rendered, leave the DOM and the scroll
+		// position alone rather than rebuilding and restarting an in-progress scroll
+		const signature = contentSignature(cities);
+		if (signature === this.lastContentSignature && list.children.length > 0) return;
+		this.lastContentSignature = signature;
+
+		list.innerHTML = '';
 
 		const lines = cities.map((city) => {
 			if (city.error) return false;
@@ -133,6 +151,18 @@ class TravelForecast extends WeatherDisplay {
 			return this.fillTemplate('travel-row', fillValues);
 		}).filter((d) => d);
 		list.append(...lines);
+
+		// The scroll cache is invalidated by comparing element identity, but .travel-lines is
+		// persistent - only its children are replaced above - and displayHeight is a fixed value
+		// from css. Both conditions in baseCountChange() therefore stay false after the first
+		// measurement, so maxOffset keeps the height of whatever content was measured first and
+		// clamps the scroll partway through anything taller, leaving it frozen there. Invalidate
+		// explicitly so the next base count re-measures.
+		this.scrollCache.displayHeight = 0;
+		this.scrollCache.travelLines = null;
+
+		// new content scrolls from the top
+		this.navBaseCount = 0;
 
 		// update timing based on actual content
 		this.setTiming(list);


### PR DESCRIPTION
## Symptom

The vertical scroll on the hazards screen stops partway through a long advisory and sits frozen at one position for the rest of the screen's timing. The bottom crawl keeps running, so only the vertical scroll is affected. Hourly and travel forecast share the same code and the same failure.

I hit this on a 24/7 kiosk during a tropical storm watch: three active alerts, ~15k characters total. The screen would scroll a short way in, stop, and hold.

## Root cause

The scroll cache is invalidated by comparing element identity:

- `server/scripts/modules/hazards.mjs:200`
- `server/scripts/modules/hourly.mjs:146`
- `server/scripts/modules/travelforecast.mjs:172`

```js
if (this.scrollCache.hazardLines !== hazardLines || this.scrollCache.displayHeight === 0) {
```

Neither condition can become true again after the first measurement:

- the lines element is persistent — `drawLongCanvas` only replaces its children via `innerHTML = ''`, so identity never changes
- `displayHeight` is `.main`'s height, a fixed value from css, so it is never `0` again

So `maxOffset` keeps the height of whatever content was measured first, for the life of the page. `setTiming` re-measures correctly on every rebuild and lengthens `timing.delay` to match the new content, but `baseCountChange` still clamps the offset with the old `maxOffset`. The scroll reaches the old content's end partway through the new content and holds there until the (now longer) delay expires.

It needs content to change on an already-loaded page, which is why it shows up on long-running displays rather than on a fresh load.

## Fix

Two changes per display, both small:

1. **Invalidate the cache explicitly** when the list is rebuilt (`displayHeight = 0`, lines ref `null`), and reset `navBaseCount` so new content scrolls from the top.

2. **Skip the rebuild when nothing changed.** Invalidating alone regresses hazards: it refreshes every 60 seconds, but a long multi-alert scroll can run for minutes, so rebuilding on every refresh restarts it from the top and it never reaches the end. Each display now compares a cheap signature of the content it is about to render and returns early if it matches, leaving an in-progress scroll untouched. Hourly's signature includes the starting hour because its row labels are derived from the current time, so an hour rollover is a real change even when the forecast values are not.

## Reproduction

Content has to change while the page is already up:

- **Hazards** — have a short alert active (a rip current statement), let the hazards screen run once, then wait for a long multi-alert advisory to be issued. The scroll stops at roughly where the short alert ended. The 10-refresh `viewedAlerts` clear also changes the rendered set, so this can recur on one page load.
- **Travel forecast** — start with some cities failing their forecast fetch (failed rows are dropped from the rendered list), then let them recover on a later refresh. The row count grows and the scroll clamps at the shorter height.

I checked the patch by extracting the real `drawLongCanvas` / `setTiming` / `baseCountChange` from this repo's files, pristine and patched, and running both through those scenarios. On pristine code both displays freeze short of the end; patched, both reach it, and an identical hazards refresh mid-scroll leaves the offset and `navBaseCount` untouched.

## Possibly #224

#224 reports the travel forecast sticking after a browser refresh, stopping on a city mid-list while the bottom crawl keeps going. That matches this failure mode — travel drops rows for cities whose forecast failed, so the rendered row count changes between renders and the stale `maxOffset` clamps the scroll mid-list. I could not reproduce that report directly, so I would not close it on this alone, but it looks like the same root cause and is worth a re-test against this branch.

## Notes

- Verified with `npm run lint` (clean) and `npm run build` (compiles clean) on this branch. `npm run lintall` reports one pre-existing `puppeteer` resolution error in `tests/index.mjs` that is present on unmodified `main` and unrelated to this change. I did not run `tests/` — it is a live-API smoke test and does not exercise this path.
- Deliberately not included: I also have a duration cap for very long advisories and a requestAnimationFrame smoothing layer for the stepped scroll, but both are behaviour/opinion changes rather than fixes for this bug, so I left them out. Happy to open either separately if they are of interest.
