### PR TITLE
Fix pressure row showing NaN in current conditions

### DIFF
--- a/server/scripts/modules/currentweather.mjs
+++ b/server/scripts/modules/currentweather.mjs
@@ -225,6 +225,10 @@ class CurrentWeather extends WeatherDisplay {
 			fill['heat-index'] = this.data.WindChill + String.fromCharCode(176);
 		}
 
+		if (!Number.isNaN(Number(this.data.Pressure))) {
+			filledTemplate.querySelector('.row.pressure-row').classList.remove('hidden');
+		}
+
 		const area = this.elem.querySelector('.main');
 
 		area.innerHTML = '';

--- a/views/partials/current-weather.ejs
+++ b/views/partials/current-weather.ejs
@@ -1,51 +1,51 @@
 <%- include('header.ejs', {titleDual:{ top: 'Current' , bottom: 'Conditions' }, noaaLogo: true, hasTime: true}) %>
-<div class="main has-scroll has-box current-weather can-enhance">
-  <div class="weather template">
-		<div class="portrait-location portrait-only"></div>
-    <div class="left col">
-      <div class="temp center"></div>
-      <div class="condition center"></div>
-      <div class="icon center"><img src="" /></div>
-      <div class="wind-container standard-only">
-        <div class="wind-label">Wind:</div>
-        <div class="wind"></div>
+  <div class="main has-scroll has-box current-weather can-enhance">
+    <div class="weather template">
+      <div class="portrait-location portrait-only"></div>
+      <div class="left col">
+        <div class="temp center"></div>
+        <div class="condition center"></div>
+        <div class="icon center"><img src="" /></div>
+        <div class="wind-container standard-only">
+          <div class="wind-label">Wind:</div>
+          <div class="wind"></div>
+        </div>
+        <div class="wind-gusts standard-only"></div>
       </div>
-      <div class="wind-gusts standard-only"></div>
-    </div>
-    <div class="right col">
-      <div class="location standard-only"></div>
-			<div class="row portrait-only">
-				<div class="label">Wind:</div>
-				<div class="wind-portrait value"></div>
-			</div>
-			<div class="row portrait-only hidden">
-				<div class="label">Gusts to:</div>
-				<div class="wind-gust-portrait value"></div>
-			</div>
-      <div class="row">
-        <div class="label">Humidity:</div>
-        <div class="humidity value"></div>
-      </div>
-      <div class="row">
-        <div class="label">Dewpoint:</div>
-        <div class="dewpoint value"></div>
-      </div>
-      <div class="row">
-        <div class="label">Ceiling:</div>
-        <div class="ceiling value"></div>
-      </div>
-      <div class="row">
-        <div class="label">Visibility:</div>
-        <div class="visibility value"></div>
-      </div>
-      <div class="row">
-        <div class="label">Pressure:</div>
-        <div class="pressure value"></div>
-      </div>
-      <div class="row">
-        <div class="heat-index-label label"></div>
-        <div class="heat-index value"></div>
+      <div class="right col">
+        <div class="location standard-only"></div>
+        <div class="row portrait-only">
+          <div class="label">Wind:</div>
+          <div class="wind-portrait value"></div>
+        </div>
+        <div class="row portrait-only hidden">
+          <div class="label">Gusts to:</div>
+          <div class="wind-gust-portrait value"></div>
+        </div>
+        <div class="row">
+          <div class="label">Humidity:</div>
+          <div class="humidity value"></div>
+        </div>
+        <div class="row">
+          <div class="label">Dewpoint:</div>
+          <div class="dewpoint value"></div>
+        </div>
+        <div class="row">
+          <div class="label">Ceiling:</div>
+          <div class="ceiling value"></div>
+        </div>
+        <div class="row">
+          <div class="label">Visibility:</div>
+          <div class="visibility value"></div>
+        </div>
+        <div class="row pressure-row hidden">
+          <div class="label">Pressure:</div>
+          <div class="pressure value"></div>
+        </div>
+        <div class="row">
+          <div class="heat-index-label label"></div>
+          <div class="heat-index value"></div>
+        </div>
       </div>
     </div>
   </div>
-</div>


### PR DESCRIPTION
Some locations such as Denver return no pressure reading, which appears as "NaN" in the Current Conditions display. Hide the pressure row by default and only reveal it when the value is a valid number.