### PR TITLE
Regional forecast: skip points with a null grid instead of requesting gridpoints/null

### DIFF
--- a/server/scripts/modules/regionalforecast.mjs
+++ b/server/scripts/modules/regionalforecast.mjs
@@ -302,10 +302,21 @@ const getAndFormatPoint = async (lat, lon) => {
 		if (!point) {
 			return null;
 		}
+		const { gridX, gridY, gridId } = point.properties ?? {};
+		// api.weather.gov returns 200 with gridId/gridX/gridY all null for offshore
+		// marine stations (forecastOffice NH2), which have no land grid. Returning the
+		// object anyway is truthy, so the caller's `if (!point)` check passes and the
+		// request becomes gridpoints/null/null,null/forecast, which 404s. Treat a
+		// missing grid the same as a missing point so the city is skipped.
+		if (gridX === null || gridX === undefined
+			|| gridY === null || gridY === undefined
+			|| gridId === null || gridId === undefined) {
+			return null;
+		}
 		return {
-			x: point.properties.gridX,
-			y: point.properties.gridY,
-			wfo: point.properties.gridId,
+			x: gridX,
+			y: gridY,
+			wfo: gridId,
 		};
 	} catch (error) {
 		throw new Error(`Unexpected error getting point for ${lat},${lon}: ${error.message}`);


### PR DESCRIPTION
## Symptom

The regional forecast issues requests to a literally-null gridpoint, which always 404:

```
https://api.weather.gov/gridpoints/null/null,null/forecast
https://api.weather.gov/gridpoints/null/null,null/stations?limit=10
```

## Cause

`api.weather.gov/points/{lat},{lon}` returns **HTTP 200** for offshore marine stations — those whose `forecastOffice` is `NH2` — but with `gridId`, `gridX` and `gridY` all explicitly `null`, because there is no land grid for them.

`getAndFormatPoint()` copies those three fields through without checking them:

```js
return {
  x: point.properties.gridX,   // null
  y: point.properties.gridY,   // null
  wfo: point.properties.gridId, // null
};
```

The result is a **truthy object with null fields**, so the caller's guard at `regionalforecast.mjs` cannot catch it:

```js
const point = city?.point ?? (await getAndFormatPoint(city.lat, city.lon));
if (!point) { ... return false; }   // passes -- point is an object
```

Both consumers then build the URL from those nulls: the forecast request in `regionalforecast.mjs`, and the stations request in `regionalforecast-utils.mjs` (`getRegionalObservation`).

## Evidence

Confirmed against the live API. Two stations in `stations.json` reproduce it:

| Station | Name | Coordinates | `/points` response |
|---|---|---|---|
| `KGHB` | GB172 | 27.840, -91.988 | 200, `gridId: null`, `gridX: null`, `gridY: null`, `forecastOffice: .../offices/NH2` |
| `KVAF` | East Breaks 643 | 27.354, -94.625 | 200, `gridId: null`, `gridX: null`, `gridY: null`, `forecastOffice: .../offices/NH2` |

For contrast, a nearby *land* station resolves normally — `KDSF` (Mississippi Canyon, 28.350, -88.267) returns `gridId: "LIX"`.

**This is not a race.** `getAndFormatPoint` is awaited before its result is used, and each case reproduces when a single location is loaded in isolation with a 20 s settle — so it is not contamination from a previously loaded location either.

## Reproducing with the existing test harness

Visible through `tests/index.mjs` without any changes to it. **Houston, Texas** and **San Antonio, Texas** both pull Gulf platforms into their regional map, and each emits the two 404s above. With `?debug=verbose-failures` the harness names them:

```
Unable to get regional stations for GB172
Regional Forecast request for GB172 failed
Unable to get regional stations for East Breaks 643
Regional Forecast request for East Breaks 643 failed
```

## Fix

Validate the fields rather than just the wrapper object, and return `null` when any of `gridId` / `gridX` / `gridY` is missing.

The affected city is then skipped and drops off the regional map — the same outcome the module already produces when a point fails to load, and consistent with the intent noted in `getData()`:

> there are enough other cities available to populate the map sufficiently even if some do not load

Scope is one function. There is a single call site, whose existing `if (!point)` guard handles the `null` return identically to a missing point; `getRegionalObservation()` is invoked after that guard, so it can no longer receive null fields either. No change to city selection, map rendering, or `stations.json`.

## Verification

- `npm run lint` — clean.
- After the change, the four 404s from Houston and San Antonio are gone, and re-running `tests/index.mjs` across the full location list shows no new failures.
- Also exercised for ~4 minutes on a continuously-running instance with no interaction: 18 gridpoint calls, zero null-grid requests, zero warnings.
